### PR TITLE
Adding defaults for edgerc credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Options:
 | - | - |
 | -V, --version | Display the version number for the Sandbox CLI program. |
 | --debug | Show debug information. |
-| --edgerc `<path>` | Use credentials in `edgerc` file for command. |
-| --section `<name>` | Use this section in `edgerc` file. |
+| --edgerc `<path>` | Use credentials in `edgerc` file for command. (Default file location is _~/.edgerc_) |
+| --section `<name>` | Use this section in `edgerc` file. (Default section is _[default]_|
 | -h, --help | Display usage information for the Sandbox CLI. |
  
 Commands:


### PR DESCRIPTION
The readme was missing information on the default file location for _.edgerc_ file and the default section used by the command. Since different APIs tend expect different sections, it is better to clearly document this.